### PR TITLE
Rails 5 Support

### DIFF
--- a/lib/rails_warden.rb
+++ b/lib/rails_warden.rb
@@ -2,7 +2,6 @@
 require 'warden'
 require 'active_support'
 
-
 $:.unshift File.expand_path(File.dirname(__FILE__))
 require "rails_warden/manager"
 require "rails_warden/rails_settings"
@@ -89,13 +88,28 @@ if !defined?(Rails::Railtie)
 else
   class RailsWarden::Railtie < Rails::Railtie
     include_block = Proc.new {
-      ::ActionController::Base.class_eval do
-        include RailsWarden::Mixins::HelperMethods
-        include RailsWarden::Mixins::ControllerOnlyMethods
+      
+      ActiveSupport.on_load(:action_controller) do
+        ::ActionController::Base.class_eval do
+          include RailsWarden::Mixins::HelperMethods
+          include RailsWarden::Mixins::ControllerOnlyMethods
+        end
+        if defined? ::ActionController::API
+          ::ActionController::API.class_eval do
+            include RailsWarden::Mixins::HelperMethods
+            include RailsWarden::Mixins::ControllerOnlyMethods
+            # TODO use the Rails 5 helper vs include
+            # /Users/jspooner/v/rails_warden/lib/rails_warden.rb:100:in `block (3 levels) in <class:Railtie>': undefined method `helper' for ActionController::API:Class (NoMethodError)
+            # helper RailsWarden::Mixins::HelperMethods
+            # helper RailsWarden::Mixins::ControllerOnlyMethods
+          end
+        end
       end
 
-      ::ActionView::Base.class_eval do
-        include RailsWarden::Mixins::HelperMethods
+      ActiveSupport.on_load(:action_view) do
+        ::ActionView::Base.class_eval do
+          include RailsWarden::Mixins::HelperMethods
+        end
       end
     }
 


### PR DESCRIPTION
1. class_eval needed to be wrapped in a ActiveSupport.on_load(:action_controller) block
2. If the rails version has ::ActionController::API we also add the helper methods there also.
3. ActionView::Base class_eval was clobbering existing controller helpers when not wrapped in a ActiveSupport.on_load(:action_view) block